### PR TITLE
feat: add multiselect support for choices input

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,12 @@ Clifer supports various input types with full TypeScript inference:
 // Boolean flag
 .option(input('force').description('Force operation'))
 
-// Choice input
+// Choice input (single select)
 .option(input('env').string().choices(['dev', 'staging', 'prod']))
+
+// Choice input (multi select - accepts comma-separated values)
+.option(input('languages').string().choices(['en', 'ml', 'fr']).multiselect())
+// CLI: --languages=en,ml  →  ['en', 'ml']
 
 // Required argument
 .argument(input('file').string().required())
@@ -233,6 +237,7 @@ Creates a new input (argument or option) with the following methods:
 - `.required()`: Mark as required
 - `.default(value)`: Set default value
 - `.choices(array)`: Limit to specific choices
+- `.multiselect()`: Allow multiple choices (comma-separated via CLI, checkbox prompt interactively)
 - `.prompt(text?)`: Enable interactive prompt
 - `.validate(fn)`: Add custom validation
 

--- a/src/cli-input-builder.ts
+++ b/src/cli-input-builder.ts
@@ -61,6 +61,11 @@ class NonBooleanInputBuilder<T, V extends InputValueType> extends BaseInputBuild
     this.input.choices = values
     return this
   }
+
+  multiselect() {
+    this.input.isMultiSelect = true
+    return this
+  }
 }
 
 export class InputBuilder<T, V extends InputValueType> extends BaseInputBuilder<T, V> {

--- a/src/cli-prompt.ts
+++ b/src/cli-prompt.ts
@@ -17,7 +17,9 @@ export async function prompt(...inputOrBuilders: InputOrBuilder<any, any>[]) {
       const choices = [...(input.choices ?? [])].map(i => `${i}`)
       return {
         type: isMultiChoice
-          ? 'autocomplete'
+          ? input.isMultiSelect
+            ? 'multiselect'
+            : 'autocomplete'
           : isBoolean
           ? 'confirm'
           : isNumber

--- a/src/cli-runner.ts
+++ b/src/cli-runner.ts
@@ -32,6 +32,20 @@ function parseValue(
   const { type, choices } = input
   switch (type) {
     case InputType.String:
+      if (input.isMultiSelect && choices?.length) {
+        const values = typeof value === 'string' ? value.split(',').map(v => v.trim()) : [value]
+        const invalid = values.filter(v => !choices.includes(v))
+        if (invalid.length) {
+          throw new CliError(
+            `Invalid value "${invalid.join(', ')}" for the input "--${
+              input.name as string
+            }". You must provide ${toValues(choices)}`,
+            command,
+            parentCommands,
+          )
+        }
+        return values
+      }
       if (choices?.length && !choices.includes(value)) {
         throw new CliError(
           `Invalid value "${value}" for the input "--${

--- a/src/cli-runner.ts
+++ b/src/cli-runner.ts
@@ -33,8 +33,9 @@ function parseValue(
   switch (type) {
     case InputType.String:
       if (input.isMultiSelect && choices?.length) {
-        const values = typeof value === 'string' ? value.split(',').map(v => v.trim()) : [value]
-        const invalid = values.filter(v => !choices.includes(v))
+        const values: string[] =
+          typeof value === 'string' ? value.split(',').map(v => v.trim()) : [String(value)]
+        const invalid = values.filter(v => !(choices as string[]).includes(v))
         if (invalid.length) {
           throw new CliError(
             `Invalid value "${invalid.join(', ')}" for the input "--${

--- a/src/cli-types.ts
+++ b/src/cli-types.ts
@@ -27,6 +27,7 @@ export interface Input<T, V extends InputValueType> {
   default?: V
   choices?: Array<V>
   isRequired?: boolean
+  isMultiSelect?: boolean
   shouldPrompt?: boolean
   promptMessage?: string
 }


### PR DESCRIPTION
## Summary
- Add `.multiselect()` modifier for `.choices()` inputs
- CLI accepts comma-separated values (e.g. `--languages=en,ml`), each validated against choices
- Interactive prompts use checkbox-style multiselect instead of autocomplete
- Updated README with usage examples and API reference

## Test plan
- [ ] Verify comma-separated CLI values are parsed into arrays
- [ ] Verify invalid values in multiselect are rejected with error
- [ ] Verify interactive multiselect prompt shows checkboxes
- [ ] Verify existing single-choice behavior is unchanged