### PR TITLE
feat: support comma-separated strings in multiselect

### DIFF
--- a/src/cli-runner.test.ts
+++ b/src/cli-runner.test.ts
@@ -418,6 +418,46 @@ describe('cli', () => {
     )
   })
 
+  test('should parse multiselect option with comma-separated string', async () => {
+    const run = jest.fn()
+    await runCli(
+      cli<any>('mycli')
+        .version('1.0')
+        .option(input('fields').string().choices(['name', 'age', 'email']).multiselect())
+        .handle(run),
+      ['--fields=name,age'],
+    )
+    expect(run).toHaveBeenCalledWith({ fields: ['name', 'age'] })
+  })
+
+  test('should parse multiselect option without choices', async () => {
+    const run = jest.fn()
+    await runCli(
+      cli<any>('mycli')
+        .version('1.0')
+        .option(input('tags').string().multiselect())
+        .handle(run),
+      ['--tags=a,b,c'],
+    )
+    expect(run).toHaveBeenCalledWith({ tags: ['a', 'b', 'c'] })
+  })
+
+  test('should throw error for invalid multiselect values', async () => {
+    const run = jest.fn()
+    console.error = jest.fn()
+    await runCli(
+      cli<any>('mycli')
+        .version('1.0')
+        .option(input('fields').string().choices(['name', 'age', 'email']).multiselect())
+        .handle(run),
+      ['--fields=name,invalid'],
+    )
+    expect(run).not.toHaveBeenCalled()
+    expect(console.error).toHaveBeenCalledWith(
+      '\nError: Invalid value "invalid" for the input "--fields". You must provide "name", "age" or "email"\n',
+    )
+  })
+
   test('should show help of a subcommand', async () => {
     const run = jest.fn()
     const runInner = jest.fn()

--- a/src/cli-runner.ts
+++ b/src/cli-runner.ts
@@ -24,7 +24,7 @@ function toValues(value: string[]) {
 }
 
 function parseValue(
-  value: string | boolean,
+  value: string | boolean | string[],
   input: Input<any, any>,
   command: Command<any>,
   parentCommands: Command<any>[],
@@ -32,18 +32,23 @@ function parseValue(
   const { type, choices } = input
   switch (type) {
     case InputType.String:
-      if (input.isMultiSelect && choices?.length) {
-        const values: string[] =
-          typeof value === 'string' ? value.split(',').map(v => v.trim()) : [String(value)]
-        const invalid = values.filter(v => !(choices as string[]).includes(v))
-        if (invalid.length) {
-          throw new CliError(
-            `Invalid value "${invalid.join(', ')}" for the input "--${
-              input.name as string
-            }". You must provide ${toValues(choices)}`,
-            command,
-            parentCommands,
-          )
+      if (input.isMultiSelect) {
+        const values: string[] = Array.isArray(value)
+          ? value
+          : typeof value === 'string'
+          ? value.split(',').map(v => v.trim())
+          : [String(value)]
+        if (choices?.length) {
+          const invalid = values.filter(v => !(choices as string[]).includes(v))
+          if (invalid.length) {
+            throw new CliError(
+              `Invalid value "${invalid.join(', ')}" for the input "--${
+                input.name as string
+              }". You must provide ${toValues(choices)}`,
+              command,
+              parentCommands,
+            )
+          }
         }
         return values
       }


### PR DESCRIPTION
## Summary
- `parseValue` now accepts `string[]` (from enquirer multiselect prompt) and comma-separated strings (from CLI args)
- Multiselect works with and without `choices()` validation
- Added 3 test cases for multiselect parsing

## Test plan
- [ ] Verify `--fields=name,age` with choices returns `['name', 'age']`
- [ ] Verify `--tags=a,b,c` without choices returns `['a', 'b', 'c']`
- [ ] Verify invalid values with choices throws appropriate error
- [ ] Verify enquirer multiselect prompt array passthrough works