### PR TITLE
Rename .multiselect() to .many()

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Clifer supports various input types with full TypeScript inference:
 .option(input('env').string().choices(['dev', 'staging', 'prod']))
 
 // Choice input (multi select - accepts comma-separated values)
-.option(input('languages').string().choices(['en', 'ml', 'fr']).multiselect())
+.option(input('languages').string().choices(['en', 'ml', 'fr']).many())
 // CLI: --languages=en,ml  →  ['en', 'ml']
 
 // Required argument
@@ -237,7 +237,7 @@ Creates a new input (argument or option) with the following methods:
 - `.required()`: Mark as required
 - `.default(value)`: Set default value
 - `.choices(array)`: Limit to specific choices
-- `.multiselect()`: Allow multiple choices (comma-separated via CLI, checkbox prompt interactively)
+- `.many()`: Allow multiple choices (comma-separated via CLI, checkbox prompt interactively)
 - `.prompt(text?)`: Enable interactive prompt
 - `.validate(fn)`: Add custom validation
 

--- a/src/cli-help.test.ts
+++ b/src/cli-help.test.ts
@@ -204,6 +204,38 @@ describe('cli', () => {
     )
   })
 
+  test('should show many indicator for options with many()', () => {
+    const help = toHelp(
+      cli<any>('mycli')
+        .option(input('languages').description('Supported languages').string().choices(['en', 'ml', 'fr']).many())
+        .option(input('tags').description('Tags to apply').string().many())
+        .option(input('env').description('Target environment').string().choices(['dev', 'staging', 'prod']))
+        .toCommand(),
+      '',
+      true,
+    )
+    expect(trim(help)).toEqual(
+      trim(`
+        mycli   [--languages=<en|ml|fr>,...] [--tags=<string>,...] [--env=<dev|staging|prod>]
+        [--help] [--doc]
+
+        OPTIONS
+
+        --languages=<en|ml|fr>,...   Supported languages
+
+        --tags=<string>,...          Tags to apply
+
+        --env=<dev|staging|prod>     Target environment
+
+        COMMON
+
+        --help                       Show help
+
+        --doc                        Generate documentation
+      `),
+    )
+  })
+
   test('should generate documentation', () => {
     const help = toDocumentation(
       cli<any>('mycli')

--- a/src/cli-help.ts
+++ b/src/cli-help.ts
@@ -94,10 +94,10 @@ function toInputHelp(input: Command<any> | Input<any, any>): string[] {
 
 function toOptionType(input: Input<any, any>): string {
   if (input.choices?.length) {
-    return `=<${input.choices?.join('|')}>`
+    return `=<${input.choices?.join('|')}>${input.isMany ? ',...' : ''}`
   }
   return input.type === InputType.String
-    ? '=<string>'
+    ? `=<string>${input.isMany ? ',...' : ''}`
     : input.type === InputType.Number
     ? '=<number>'
     : ''

--- a/src/cli-input-builder.ts
+++ b/src/cli-input-builder.ts
@@ -62,8 +62,8 @@ class NonBooleanInputBuilder<T, V extends InputValueType> extends BaseInputBuild
     return this
   }
 
-  multiselect() {
-    this.input.isMultiSelect = true
+  many() {
+    this.input.isMany = true
     return this
   }
 }

--- a/src/cli-prompt.ts
+++ b/src/cli-prompt.ts
@@ -17,7 +17,7 @@ export async function prompt(...inputOrBuilders: InputOrBuilder<any, any>[]) {
       const choices = [...(input.choices ?? [])].map(i => `${i}`)
       return {
         type: isMultiChoice
-          ? input.isMultiSelect
+          ? input.isMany
             ? 'multiselect'
             : 'autocomplete'
           : isBoolean

--- a/src/cli-runner.test.ts
+++ b/src/cli-runner.test.ts
@@ -418,37 +418,37 @@ describe('cli', () => {
     )
   })
 
-  test('should parse multiselect option with comma-separated string', async () => {
+  test('should parse many option with comma-separated string', async () => {
     const run = jest.fn()
     await runCli(
       cli<any>('mycli')
         .version('1.0')
-        .option(input('fields').string().choices(['name', 'age', 'email']).multiselect())
+        .option(input('fields').string().choices(['name', 'age', 'email']).many())
         .handle(run),
       ['--fields=name,age'],
     )
     expect(run).toHaveBeenCalledWith({ fields: ['name', 'age'] })
   })
 
-  test('should parse multiselect option without choices', async () => {
+  test('should parse many option without choices', async () => {
     const run = jest.fn()
     await runCli(
       cli<any>('mycli')
         .version('1.0')
-        .option(input('tags').string().multiselect())
+        .option(input('tags').string().many())
         .handle(run),
       ['--tags=a,b,c'],
     )
     expect(run).toHaveBeenCalledWith({ tags: ['a', 'b', 'c'] })
   })
 
-  test('should throw error for invalid multiselect values', async () => {
+  test('should throw error for invalid many values', async () => {
     const run = jest.fn()
     console.error = jest.fn()
     await runCli(
       cli<any>('mycli')
         .version('1.0')
-        .option(input('fields').string().choices(['name', 'age', 'email']).multiselect())
+        .option(input('fields').string().choices(['name', 'age', 'email']).many())
         .handle(run),
       ['--fields=name,invalid'],
     )

--- a/src/cli-runner.ts
+++ b/src/cli-runner.ts
@@ -32,7 +32,7 @@ function parseValue(
   const { type, choices } = input
   switch (type) {
     case InputType.String:
-      if (input.isMultiSelect) {
+      if (input.isMany) {
         const values: string[] = Array.isArray(value)
           ? value
           : typeof value === 'string'

--- a/src/cli-types.ts
+++ b/src/cli-types.ts
@@ -27,7 +27,7 @@ export interface Input<T, V extends InputValueType> {
   default?: V
   choices?: Array<V>
   isRequired?: boolean
-  isMultiSelect?: boolean
+  isMany?: boolean
   shouldPrompt?: boolean
   promptMessage?: string
 }


### PR DESCRIPTION
## Summary
- Rename `.multiselect()` builder method to `.many()` for a shorter, cleaner API
- Rename internal `isMultiSelect` property to `isMany` across types, runner, and prompt
- Add `,...` suffix in help output for `.many()` options (e.g., `--languages=<en|ml|fr>,...`)
- Add test coverage for `.many()` help indicator

## Test plan
- [x] All 38 existing tests pass
- [x] New help output test verifies `,...` suffix for both choices-based and free-form many inputs