### PR TITLE
refactor: rename render() to renderUI()

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,10 +410,10 @@ Add `.format()` to any command to enable a `--format=<default|text|json>` option
 | `--format=json`   | JSON    | Machine-readable, structured data |
 | `--doc`           | Docs    | Auto-generated markdown documentation |
 
-Use the `render()` function to support all three modes with a single call:
+Use the `renderUI()` function to support all three modes with a single call:
 
 ```typescript
-import { render } from 'clifer'
+import { renderUI } from 'clifer'
 import type { FormatProps } from 'clifer'
 
 interface Props extends FormatProps {}
@@ -422,7 +422,7 @@ const program = cli<Props>('status')
   .format()  // adds --format=<default|text|json>
   .handle(async (props) => {
     const data = { status: 'running', port: 3000 }
-    render(data, props.format, (data) => (
+    renderUI(data, props.format, (data) => (
       <Card title="Server Status">
         <LabelValue label="Status" value={data.status} />
         <LabelValue label="Port" value={String(data.port)} />
@@ -937,7 +937,7 @@ Configuration saved!
 
 | Function                        | Description                                 |
 | ------------------------------- | ------------------------------------------- |
-| `render(data, format, richFn)`  | Unified renderer (rich/text/json)           |
+| `renderUI(data, format, richFn)` | Unified renderer (rich/text/json)           |
 | `renderOnce(element)`           | Render an Ink component once and unmount    |
 | `printJson(data)`               | Print data as JSON                          |
 | `printText(data)`               | Print object as formatted key-value pairs   |

--- a/src/cli-output.ts
+++ b/src/cli-output.ts
@@ -280,9 +280,9 @@ export function formatAsList(items: any[], fields?: string[]): string {
   return [header, separator, ...rows].join('\n')
 }
 
-// --- Unified render() dispatcher ---
+// --- Unified renderUI() dispatcher ---
 
-export function render<T>(
+export function renderUI<T>(
   data: T,
   format: OutputFormat,
   richFn: RichRenderer<T>,

--- a/src/example/output.tsx
+++ b/src/example/output.tsx
@@ -17,7 +17,7 @@ import {
   printMarkdown,
   printText,
   printTextList,
-  render,
+  renderUI,
   renderOnce,
   runCli,
 } from '..'
@@ -157,7 +157,7 @@ async function showUIComponents() {
 
 async function showRenderDispatcher(format: OutputFormat) {
   // render() automatically picks the right output based on --format flag
-  await render(deployInfo, format, data => <KeyValueTable title="Deploy Info" data={data} />)
+  await renderUI(deployInfo, format, data => <KeyValueTable title="Deploy Info" data={data} />)
 }
 
 // --- CliExpectedError example ---


### PR DESCRIPTION
## Summary
- Rename the `render()` export to `renderUI()` to avoid ambiguity with Ink's own `render`
- Update usage in example and README documentation

## Test plan
- [x] TypeScript type-check passes (`npx tsc --noEmit`)
- [ ] Verify `renderUI` works with `--format=default`, `--format=text`, `--format=json`